### PR TITLE
fix(fonts): move font import to top of main scss file

### DIFF
--- a/static/static/scss/_imports.scss
+++ b/static/static/scss/_imports.scss
@@ -1,6 +1,3 @@
-// Font
-@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700");
-
 // Utilities
 @import "utilities/flexbox";
 @import "utilities/helpers";

--- a/static/static/scss/hxui.scss
+++ b/static/static/scss/hxui.scss
@@ -1,3 +1,6 @@
+// Font
+@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700");
+
 // Functions
 @import "utilities/functions";
 


### PR DESCRIPTION
### Description

Move font @import from _imports.scss to the top of the main scss file - node-sass rendered this correctly at the top of the compiled css, but sass was rendering it in the hxui declaration block, causing it to be ignored by the browser.

### Change

- [x] Bug fix (non-breaking change, fixes an issue)
- ~New feature (non-breaking change, adds functionality)~
- ~Breaking change (causing existing functionality to not work as expected)~
- ~This change requires a documentation update~

### Checklist

- [x] I have self-reviewed my code
- ~I have added comments to my code for hard-to-understand areas~
- ~I have added tests that confirm my code works as intended~