### PR TITLE
fix: update font to css api v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/MedicalDirector/hxui-css/compare/v1.5.4...HEAD)
 
+### Fixed
+
+- Relocate fonts import to main file, support Google Fonts CSS API v2, change font weight from 600 (non-existent) to 700
+
 ## [1.5.4](https://github.com/MedicalDirector/hxui-css/compare/v1.5.3...v1.5.4) - 2022-06-06
 
 ### Added

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,15 +7,15 @@ export default {
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: 'Nuxt.js project' }
+      { hid: 'description', name: 'description', content: 'Nuxt.js project' },
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
-      { rel: 'stylesheet', media: 'all', href: '/' }
+      { rel: 'stylesheet', media: 'all', href: '/' },
     ],
     htmlAttrs: {
-      class: 'hxui-reset'
-    }
+      class: 'hxui-reset',
+    },
   },
   target: 'static',
   /*
@@ -34,11 +34,11 @@ export default {
         [
           '@nuxt/babel-preset-app',
           {
-            corejs: { version: 3 }
-          }
-        ]
-      ]
-    }
+            corejs: { version: 3 },
+          },
+        ],
+      ],
+    },
   },
   buildModules: ['@nuxtjs/google-fonts'],
   /**
@@ -48,8 +48,8 @@ export default {
    */
   googleFonts: {
     families: {
-      Roboto: [300, 400, 500, 600, 700]
-    }
+      Roboto: [300, 400, 500, 700],
+    },
   },
   /*
    * CSS
@@ -57,10 +57,13 @@ export default {
   css: [
     // SCSS file in the project
     '@/static/static/scss/hxui.scss',
-    'highlight.js/styles/github-dark.css'
+    'highlight.js/styles/github-dark.css',
   ],
   /*
    * Plug-ins
    */
-  plugins: ['~/plugins/vue-highlightjs', { src: '~/plugins/ga.js', ssr: false }]
+  plugins: [
+    '~/plugins/vue-highlightjs',
+    { src: '~/plugins/ga.js', ssr: false },
+  ],
 }

--- a/static/static/scss/_variables.scss
+++ b/static/static/scss/_variables.scss
@@ -249,7 +249,7 @@ $hx-font-size-xs: 0.75rem !default;
 $hx-font-weight-normal: 300 !default;
 $hx-font-weight-bolder: 400 !default;
 $hx-font-weight-bold: 500 !default;
-$hx-font-weight-boldest: 600 !default;
+$hx-font-weight-boldest: 700 !default;
 $hx-font-weight-base: $hx-font-weight-normal !default;
 
 // Line Height

--- a/static/static/scss/components/_form.scss
+++ b/static/static/scss/components/_form.scss
@@ -964,7 +964,7 @@
     .#{$namespace}-checkbox {
       + .#{$namespace}-label {
         font-size: 0.75rem;
-        font-weight: 600;
+        font-weight: 700;
       }
     }
   }

--- a/static/static/scss/hxui.scss
+++ b/static/static/scss/hxui.scss
@@ -1,5 +1,5 @@
 // Font
-@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap");
 
 // Functions
 @import "utilities/functions";

--- a/static/static/scss/utilities/_text.scss
+++ b/static/static/scss/utilities/_text.scss
@@ -79,7 +79,7 @@
 }
 
 .is-text-weight-boldest {
-  font-weight: 600 !important;
+  font-weight: 700 !important;
 }
 
 // Text


### PR DESCRIPTION
### Description

Update google font to css api v2. Change font weight 600 to 700 as both v1 and v2 of api do not return 600, it currently renders as 700 anyway.

v1 response:
![image](https://user-images.githubusercontent.com/102931971/173000102-efc68411-7f34-44e5-b90d-2902aafe0330.png)

v2 response:
![image](https://user-images.githubusercontent.com/102931971/173000390-a695a2d3-e75c-407e-973b-21ee952d327b.png)


### Change

- [x] Bug fix (non-breaking change, fixes an issue)
- ~New feature (non-breaking change, adds functionality)~
- ~Breaking change (causing existing functionality to not work as expected)~
- ~This change requires a documentation update~

### Checklist

- [x] I have self-reviewed my code
- ~I have added comments to my code for hard-to-understand areas~
- ~I have added tests that confirm my code works as intended~